### PR TITLE
Fix the bug when load a empty config file.

### DIFF
--- a/efb_wechat_slave/__init__.py
+++ b/efb_wechat_slave/__init__.py
@@ -187,7 +187,10 @@ class WeChatChannel(EFBChannel):
         if not os.path.exists(config_path):
             return
         with open(config_path) as f:
-            self.config: Dict[str, Any] = yaml.load(f)
+            d = yaml.load(f)
+            if not d:
+                return
+            self.config: Dict[str, Any] = d
 
     #
     # Utilities


### PR DESCRIPTION
* Bug
yaml.load(f) returns `None` when the config file is empty, leading the `channel.config` to be `None` and crashes when the wechat slave update its config by reading `channel.config`

* Update
Check the return value of yaml before the assignment to channel.config. 