### PR TITLE
Fix the bug of '@None'

### DIFF
--- a/efb_wechat_slave/chats.py
+++ b/efb_wechat_slave/chats.py
@@ -99,7 +99,7 @@ class ChatManager:
         if isinstance(chat, wxpy.Member):
             efb_chat.chat_type = ChatType.User
             efb_chat.is_chat = False
-            efb_chat.chat_alias = chat.display_name or efb_chat.chat_alias
+            efb_chat.chat_alias = chat.name
             # self.logger.debug("[WXPY: %s] Display name: %s;", chat.puid, chat.display_name)
             if recursive:
                 efb_chat.group = self.wxpy_chat_to_efb_chat(chat.group, False)


### PR DESCRIPTION
It is possible that both `chat.display_name` and `efb_chat.chat_alias` are `None` or ''.
`chat.name()` returns the first one who is not `None` from `{remark_name, display_name, nick_name, wxid}`.