### PR TITLE
Fix Animated Sticker Size Issues via Gif compression

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,7 @@ Added
 -----
 - Add UOS weixin desktop patch
 - Add 'replace_emoticon' flag, disable this flag to stop emoticon conversion
+- Add compression for gif files to avoid 1 MB limit
 
 Changed
 -------

--- a/README.rst
+++ b/README.rst
@@ -63,6 +63,7 @@ EWS 是兼容 EH Forwarder Bot 的微信从端，基于逆向工程的微�
 -  ffmpeg
 -  libmagic
 -  pillow
+-  gifsicle
 
 安装与启用
 ----------

--- a/efb_wechat_slave/__init__.py
+++ b/efb_wechat_slave/__init__.py
@@ -6,7 +6,6 @@ import logging
 import tempfile
 import time
 import threading
-import subprocess
 from gettext import translation
 from json import JSONDecodeError
 from pathlib import Path

--- a/efb_wechat_slave/utils.py
+++ b/efb_wechat_slave/utils.py
@@ -245,9 +245,7 @@ if os.name == "nt":
             subprocess.run(["gifsicle", "--resize-method=catrom", "--lossy=100", "-O2", "-o", compress_file.name, file.name], check=True)
             new_file_size = os.path.getsize(compress_file.name)
             if new_file_size > 1024 * 1024:
-                scales = [600, 512, 480, 400, 360, 300, 256, 250, 200, 150, 100]
-                scales = [scale for scale in scales if scale < metadata['streams'][0]['width']]
-                scales = sorted(scales, reverse=True)
+                scales = [512, 480, 400, 360, 300, 256, 250, 200, 150, 100]
                 for scale in scales:
                     subprocess.run(["gifsicle", "--resize-method=catrom",  "--resize-fit", f"{scale}x{scale}", "--lossy=100", "-O2", "-o", compress_file.name, file.name], check=True)
                     new_file_size = os.path.getsize(compress_file.name)
@@ -271,9 +269,7 @@ else:
             subprocess.run(["gifsicle", "--resize-method=catrom", "--lossy=100", "-O2", "-o", compress_file.name, file.name], check=True)
             new_file_size = os.path.getsize(compress_file.name)
             if new_file_size > 1024 * 1024:
-                scales = [600, 512, 480, 400, 360, 300, 256, 250, 200, 150, 100]
-                scales = [scale for scale in scales if scale < metadata['streams'][0]['width']]
-                scales = sorted(scales, reverse=True)
+                scales = [512, 480, 400, 360, 300, 256, 250, 200, 150, 100]
                 for scale in scales:
                     subprocess.run(["gifsicle", "--resize-method=catrom",  "--resize-fit", f"{scale}x{scale}", "--lossy=100", "-O2", "-o", compress_file.name, file.name], check=True)
                     new_file_size = os.path.getsize(compress_file.name)

--- a/efb_wechat_slave/utils.py
+++ b/efb_wechat_slave/utils.py
@@ -254,6 +254,9 @@ if os.name == "nt":
                         break
             file.close()
             file = compress_file
+        if new_file_size > 1024 * 1024:
+            raise EFBMessageError(
+                self._("Image size is too large. (IS02)"))
         file.seek(0)
         return file
 
@@ -278,5 +281,8 @@ else:
                         break
             file.close()
             file = compress_file
+        if new_file_size > 1024 * 1024:
+            raise EFBMessageError(
+                self._("Image size is too large. (IS02)"))
         file.seek(0)
         return file

--- a/efb_wechat_slave/utils.py
+++ b/efb_wechat_slave/utils.py
@@ -3,14 +3,10 @@ import base64
 import io
 import os
 import subprocess
-import sys
 import json
-from shutil import copyfileobj
 from tempfile import NamedTemporaryFile
 from typing import Dict, Any, TYPE_CHECKING, List, IO
 
-import ffmpeg
-from ffmpeg._utils import convert_kwargs_to_cmd_line_args
 
 from ehforwarderbot.types import MessageID
 from .vendor.itchat import utils as itchat_utils

--- a/efb_wechat_slave/utils.py
+++ b/efb_wechat_slave/utils.py
@@ -2,8 +2,15 @@
 import base64
 import io
 import os
+import subprocess
+import sys
 import json
-from typing import Dict, Any, TYPE_CHECKING, List
+from shutil import copyfileobj
+from tempfile import NamedTemporaryFile
+from typing import Dict, Any, TYPE_CHECKING, List, IO
+
+import ffmpeg
+from ffmpeg._utils import convert_kwargs_to_cmd_line_args
 
 from ehforwarderbot.types import MessageID
 from .vendor.itchat import utils as itchat_utils
@@ -221,3 +228,153 @@ def imgcat(file: io.BytesIO, filename: str) -> str:
     res += base64.b64encode(file.getvalue()).decode()
     res += print_st()
     return res
+
+
+if os.name == "nt":
+    # Workaround for Windows which cannot open the same file as "read" twice.
+    # Using stdin/stdout pipe for IO with ffmpeg.
+    # Said to be only working with a few encodings. It seems that Telegram GIF
+    # (MP4, h264, soundless) luckily felt in that range.
+    #
+    # See: https://etm.1a23.studio/issues/90
+
+    def ffprobe(stream: IO[bytes], cmd='ffprobe', **kwargs):
+        """Run ffprobe on an input stream and return a JSON representation of the output.
+
+        Code adopted from ffmpeg-python by Karl Kroening (Apache License 2.0).
+        Copyright 2017 Karl Kroening
+
+        Raises:
+            :class:`ffmpeg.Error`: if ffprobe returns a non-zero exit code,
+                an :class:`Error` is returned with a generic error message.
+                The stderr output can be retrieved by accessing the
+                ``stderr`` property of the exception.
+        """
+        args = [cmd, '-show_format', '-show_streams', '-of', 'json']
+        args += convert_kwargs_to_cmd_line_args(kwargs)
+        args += ["-"]
+
+        p = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE)
+        assert p.stdin
+        copyfileobj(p.stdin, stream)
+        out, err = p.communicate()
+        if p.returncode != 0:
+            raise ffmpeg.Error('ffprobe', out, err)
+        return json.loads(out.decode('utf-8'))
+
+
+    def gif_conversion(file: IO[bytes]) -> IO[bytes]:
+        """Convert Telegram GIF to real GIF, the NT way."""
+        gif_file = NamedTemporaryFile(suffix='.gif')
+        file.seek(0)
+
+        # Use custom ffprobe command to read from stream
+        metadata = ffprobe(file)
+
+        # Set input/output of ffmpeg to stream
+        stream = ffmpeg.input("pipe:")
+        if metadata['streams'][0]['codec_name'] == 'vp9':
+            stream = ffmpeg.input(file.name, vcodec='libvpx-vp9')
+        if metadata.get('width', 0) > 600:
+            stream = stream.filter("scale", 600, -2)
+        if metadata.get('fps', 0) > 12:
+            stream = stream.filter("fps", 12, round='up')
+        split = (
+            stream
+            .split()
+        )
+        stream_paletteuse = (
+            ffmpeg
+            .filter(
+                [
+                    split[0],
+                    split[1]
+                    .filter(
+                        filter_name='palettegen', 
+                        reserve_transparent='on',
+                    )
+                ],
+                filter_name='paletteuse',
+            )
+        )
+        # Need to specify file format here as no extension hint presents.
+        args = stream_paletteuse.output("pipe:", format="gif").compile()
+        file.seek(0)
+
+        # subprocess.Popen would still try to access the file handle instead of
+        # using standard IO interface. Not sure if that would work on Windows.
+        # Using the most classic buffer and copy via IO interface just to play
+        # safe.
+        p = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        assert p.stdin
+        copyfileobj(file, p.stdin)
+        p.stdin.close()
+
+        # Raise exception if error occurs, just like ffmpeg-python.
+        if p.returncode != 0 and p.stderr:
+            err = p.stderr.read().decode()
+            print(err, file=sys.stderr)
+            raise ffmpeg.Error('ffmpeg', "", err)
+
+        assert p.stdout
+        copyfileobj(p.stdout, gif_file)
+        file.close()
+        gif_file.seek(0)
+        return gif_file
+
+else:
+    def gif_conversion(file: IO[bytes]) -> IO[bytes]:
+        """Convert Telegram GIF to real GIF, the non-NT way."""
+        gif_file = NamedTemporaryFile(suffix='.gif')
+        file.seek(0)
+        metadata = ffmpeg.probe(file.name)
+        stream = ffmpeg.input(file.name)
+        # 检查视频编码类型是否为VP9
+        if metadata['streams'][0]['codec_name'] == 'vp9':
+            stream = ffmpeg.input(file.name, vcodec='libvpx-vp9') # 只有这个能保持透明背景
+        if metadata.get('fps', 0) > 12:
+            stream = stream.filter("fps", 12, round='up') # 限制帧率
+        if metadata.get('width', 0) > 600:
+            stream = stream.filter("scale", 600, -2) # 限制宽度
+        split = (
+            stream
+            .split()
+        )
+        stream_paletteuse = (
+            ffmpeg
+            .filter(
+                [
+                    split[0],
+                    split[1]
+                    .filter(
+                        filter_name='palettegen', 
+                        reserve_transparent='on',
+                    )
+                ],
+                filter_name='paletteuse',
+            )
+        )
+        stream_paletteuse.output(gif_file.name).overwrite_output().run() 
+        new_file_size = os.path.getsize(gif_file.name)
+        print(f"file_size: {new_file_size/1024}KB")
+        if new_file_size > 1024 * 1024:
+            # try to use gifsicle lossy compression
+            compress_file = NamedTemporaryFile(suffix='.gif')
+            subprocess.run(["gifsicle", "--resize-method=catrom", "--lossy=100", "-O2", "-o", compress_file.name, gif_file.name], check=True)
+            new_file_size = os.path.getsize(compress_file.name)
+            if new_file_size > 1024 * 1024:
+                scales = [600, 512, 480, 400, 360, 300, 256, 250, 200, 150, 100]
+                scales = [scale for scale in scales if scale < metadata['streams'][0]['width']]
+                scales = sorted(scales, reverse=True)
+                for scale in scales:
+                    subprocess.run(["gifsicle", "--resize-method=catrom",  "--resize-fit", f"{scale}x{scale}", "--lossy=100", "-O2", "-o", compress_file.name, gif_file.name], check=True)
+                    new_file_size = os.path.getsize(compress_file.name)
+                    print(f"new_file_size: {new_file_size/1024}KB after resize to {scale}x{scale}")
+                    if new_file_size < 1024 * 1024:
+                        break
+            gif_file.close()
+            gif_file = compress_file
+        file.close()
+        gif_file.seek(0)
+        return gif_file

--- a/efb_wechat_slave/utils.py
+++ b/efb_wechat_slave/utils.py
@@ -326,55 +326,25 @@ if os.name == "nt":
 else:
     def gif_conversion(file: IO[bytes]) -> IO[bytes]:
         """Convert Telegram GIF to real GIF, the non-NT way."""
-        gif_file = NamedTemporaryFile(suffix='.gif')
         file.seek(0)
-        metadata = ffmpeg.probe(file.name)
-        stream = ffmpeg.input(file.name)
-        # 检查视频编码类型是否为VP9
-        if metadata['streams'][0]['codec_name'] == 'vp9':
-            stream = ffmpeg.input(file.name, vcodec='libvpx-vp9') # 只有这个能保持透明背景
-        if metadata.get('fps', 0) > 12:
-            stream = stream.filter("fps", 12, round='up') # 限制帧率
-        if metadata.get('width', 0) > 600:
-            stream = stream.filter("scale", 600, -2) # 限制宽度
-        split = (
-            stream
-            .split()
-        )
-        stream_paletteuse = (
-            ffmpeg
-            .filter(
-                [
-                    split[0],
-                    split[1]
-                    .filter(
-                        filter_name='palettegen', 
-                        reserve_transparent='on',
-                    )
-                ],
-                filter_name='paletteuse',
-            )
-        )
-        stream_paletteuse.output(gif_file.name).overwrite_output().run() 
-        new_file_size = os.path.getsize(gif_file.name)
+        new_file_size = os.path.getsize(file.name)
         print(f"file_size: {new_file_size/1024}KB")
         if new_file_size > 1024 * 1024:
             # try to use gifsicle lossy compression
             compress_file = NamedTemporaryFile(suffix='.gif')
-            subprocess.run(["gifsicle", "--resize-method=catrom", "--lossy=100", "-O2", "-o", compress_file.name, gif_file.name], check=True)
+            subprocess.run(["gifsicle", "--resize-method=catrom", "--lossy=100", "-O2", "-o", compress_file.name, file.name], check=True)
             new_file_size = os.path.getsize(compress_file.name)
             if new_file_size > 1024 * 1024:
                 scales = [600, 512, 480, 400, 360, 300, 256, 250, 200, 150, 100]
                 scales = [scale for scale in scales if scale < metadata['streams'][0]['width']]
                 scales = sorted(scales, reverse=True)
                 for scale in scales:
-                    subprocess.run(["gifsicle", "--resize-method=catrom",  "--resize-fit", f"{scale}x{scale}", "--lossy=100", "-O2", "-o", compress_file.name, gif_file.name], check=True)
+                    subprocess.run(["gifsicle", "--resize-method=catrom",  "--resize-fit", f"{scale}x{scale}", "--lossy=100", "-O2", "-o", compress_file.name, file.name], check=True)
                     new_file_size = os.path.getsize(compress_file.name)
                     print(f"new_file_size: {new_file_size/1024}KB after resize to {scale}x{scale}")
                     if new_file_size < 1024 * 1024:
                         break
-            gif_file.close()
-            gif_file = compress_file
-        file.close()
-        gif_file.seek(0)
-        return gif_file
+            file.close()
+            file = compress_file
+        file.seek(0)
+        return file


### PR DESCRIPTION
The error when sending animated stickers from Telegram to WeChat via EFB is often caused by WeChat's 1 MB size limit for GIF files used as stickers. Other users have also reported similar [issues](https://github.com/ehforwarderbot/efb-wechat-slave/issues/55#issuecomment-1207138251).

![image](https://github.com/ehForwarderBot/efb-wechat-slave/assets/44089074/92fee93f-2828-4ef1-bdbd-38919ea108a5)
After investigating, I found that reducing the frame rate and image size of the GIF can help decrease the file size and mitigate these errors, which is the main approach I took in this PR.

This pull request should help alleviate the "too big file" issue when sending animated stickers from Telegram to WeChat via EFB.

---

通过 EFB 从 Telegram 发送动态表情贴图到微信时, 经常会出现错误, 这主要是由于微信对作为表情贴图的 GIF 文件有 1 MB 的大小限制所导致。其他用户也反馈了类似的[问题](https://github.com/ehforwarderbot/efb-wechat-slave/issues/55#issuecomment-1207138251)。

经过调查, 我发现降低 GIF 的帧率和图片大小可以有效减小文件体积, 从而避免这类错误。这也是我在该 PR 中采取的主要方法。

该 Pull Request 应该可以缓解从 Telegram 通过 EFB 发送动态表情贴图到微信时遇到的"文件过大"问题。